### PR TITLE
Create basic layout and Redirection feature

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+#### What is the purpose of this pull request?
+
+<!--- Describe your changes in detail. -->
+
+#### What problem is this solving?
+
+<!--- What is the motivation and context for this change? -->
+
+#### How should this be manually tested?
+
+#### Screenshots or example usage
+
+#### Types of changes
+
+* [ ] Bug fix (a non-breaking change which fixes an issue)
+* [ ] New feature (a non-breaking change which adds functionality)
+* [ ] Breaking change (fix or feature that would cause existing functionality to change)
+* [ ] Requires change to documentation, which has been updated accordingly.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+### SublimeText ###
+*.sublime-workspace
+
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+### Windows ###
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# App specific
+node_modules/
+docs/_book/
+.tmp
+.idea
+npm-debug.log
+.build/
+lib
+.eslintrc
+*.orig
+react/package-lock.json

--- a/.vtexignore
+++ b/.vtexignore
@@ -1,0 +1,16 @@
+.DS_Store
+.git
+node_modules/
+package.json
+.vscode/
+.gitignore
+tsconfig.json
+tslint.json
+typings.d.ts
+yarn.lock
+render/node_modules/
+service/node_modules/
+react/__tests__/**
+react/.babelrc
+react/.eslintrc
+react/setupTests.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- MaybeAddress component to redirect user to and from the home page
+- Greeting component prints a welcome message to the authenticated user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2018-10-24
 ### Added
 - MaybeAddress component to redirect user to and from the home page
 - Greeting component prints a welcome message to the authenticated user

--- a/manifest.json
+++ b/manifest.json
@@ -1,24 +1,40 @@
 {
-    "vendor": "vtex",
-    "name": "delivery-dreamstore",
-    "version": "0.1.0",
-    "builders": {
-      "pages": "0.x",
-      "react": "2.x"
-    },
-    "mustUpdateAt": "2018-09-05",
-    "categories": [],
-    "registries": [
-      "smartcheckout"
-    ],
-    "settingsSchema": {},
-    "scripts": {
-      "postreleasy": "vtex publish --verbose"
-    },
-    "dependencies": {
-      "vtex.carousel": "1.x",
-      "vtex.dreamstore": "1.x",
-      "vtex.styleguide": "6.x",
-      "vtex.shelf": "0.x"
-    }
+  "vendor": "vtex",
+  "name": "delivery-dreamstore",
+  "version": "0.1.0",
+  "builders": {
+    "pages": "0.x",
+    "react": "2.x"
+  },
+  "mustUpdateAt": "2018-09-05",
+  "categories": [],
+  "registries": ["smartcheckout"],
+  "settingsSchema": {},
+  "scripts": {
+    "postreleasy": "vtex publish --verbose"
+  },
+  "dependencies": {
+    "vtex.dreamstore": "1.x",
+    "vtex.address-locator": "0.x",
+    "vtex.store-graphql": "2.x",
+    "vtex.shelf": "0.x",
+    "vtex.menu": "1.x",
+    "vtex.minicart": "1.x",
+    "vtex.my-account": "0.x",
+    "vtex.product-customizer": "0.x",
+    "vtex.product-details": "0.x",
+    "vtex.product-summary": "1.x",
+    "vtex.store-components": "2.x",
+    "vtex.search-result": "2.x",
+    "vtex.category-menu": "1.x",
+    "vtex.breadcrumb": "0.x",
+    "vtex.login": "1.x",
+    "vtex.styleguide": "7.x",
+    "vtex.carousel": "1.x",
+    "vtex.store": "1.x",
+    "vtex.product-kit": "0.x",
+    "vtex.telemarketing": "1.x",
+    "vtex.dreamstore-header": "1.x",
+    "vtex.dreamstore-footer": "1.x"
   }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,24 @@
+{
+    "vendor": "vtex",
+    "name": "delivery-dreamstore",
+    "version": "0.1.0",
+    "builders": {
+      "pages": "0.x",
+      "react": "2.x"
+    },
+    "mustUpdateAt": "2018-09-05",
+    "categories": [],
+    "registries": [
+      "smartcheckout"
+    ],
+    "settingsSchema": {},
+    "scripts": {
+      "postreleasy": "vtex publish --verbose"
+    },
+    "dependencies": {
+      "vtex.carousel": "1.x",
+      "vtex.dreamstore": "1.x",
+      "vtex.styleguide": "6.x",
+      "vtex.shelf": "0.x"
+    }
+  }

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,16 @@
 {
   "vendor": "vtex",
   "name": "delivery-dreamstore",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "builders": {
     "pages": "0.x",
     "react": "2.x"
   },
   "mustUpdateAt": "2018-09-05",
   "categories": [],
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "settingsSchema": {},
   "scripts": {
     "postreleasy": "vtex publish --verbose"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -1,14 +1,72 @@
 {
+  "routes": {
+    "store/order": {
+      "path": "/order",
+      "context": "HomeContextProvider"
+    },
+    "store/home": {
+      "path": "/",
+      "landing": true
+    }
+  },
   "templates": {
+    "store": {
+      "component": "DeliveryLayoutContainer",
+      "context": "vtex.store@1.x/StoreContextProvider",
+      "props": {
+        "elements": ["__children__"]
+      }
+    },
     "home": {
       "component": "vtex.render-runtime/LayoutContainer",
       "props": {
-        "elements": [
-          "carousel",
-          "shelf"
-        ]
+        "elements": ["theme", "address"]
       },
       "extensions": {
+        "theme": {
+          "component": "Theme"
+        },
+        "address": {
+          "component": "vtex.address-locator/index"
+        }
+      }
+    },
+    "order": {
+      "component": "vtex.render-runtime/LayoutContainer",
+      "props": {
+        "elements": ["header", "address-manager", "greeting", "carousel", "last-order", "shelf"]
+      },
+      "extensions": {
+        "header": {
+          "component": "vtex.dreamstore-header/index"
+        },
+        "header/telemarketing": {
+          "component": "vtex.telemarketing/index"
+        },
+        "header/minicart": {
+          "component": "vtex.minicart/MiniCart"
+        },
+        "header/login": {
+          "component": "vtex.login/Login"
+        },
+        "header/menu-link": {
+          "component": "vtex.menu/Menu"
+        },
+        "header/category-menu": {
+          "component": "vtex.category-menu/index"
+        },
+        "header/logo": {
+          "component": "vtex.store-components/Logo"
+        },
+        "header/search-bar": {
+          "component": "vtex.store-components/SearchBar"
+        },
+        "address-manager": {
+          "component": "vtex.address-locator/AddressManager"
+        },
+        "greeting": {
+          "component": "Greeting"
+        },
         "carousel": {
           "component": "vtex.carousel/Carousel"
         },
@@ -16,13 +74,43 @@
           "component": "vtex.shelf/Shelf"
         }
       }
+    },
+    "product": {
+      "component": "vtex.render-runtime/LayoutContainer",
+      "context": "vtex.store@1.x/ProductContextProvider",
+      "props": {
+        "elements": ["customizer"]
+      },
+      "extensions": {
+        "customizer": {
+          "component": "vtex.product-customizer/ProductCustomizer"
+        }
+      }
     }
   },
   "pages": {
+    "store": [
+      {
+        "name": "Default",
+        "template": "store"
+      }
+    ],
     "store/home": [
       {
         "name": "Default",
         "template": "home"
+      }
+    ],
+    "store/order": [
+      {
+        "name": "Order",
+        "template": "order"
+      }
+    ],
+    "store/product": [
+      {
+        "name": "Product",
+        "template": "product"
       }
     ]
   }

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -1,0 +1,29 @@
+{
+  "templates": {
+    "home": {
+      "component": "vtex.render-runtime/LayoutContainer",
+      "props": {
+        "elements": [
+          "carousel",
+          "shelf"
+        ]
+      },
+      "extensions": {
+        "carousel": {
+          "component": "vtex.carousel/Carousel"
+        },
+        "shelf": {
+          "component": "vtex.shelf/Shelf"
+        }
+      }
+    }
+  },
+  "pages": {
+    "store/home": [
+      {
+        "name": "Default",
+        "template": "home"
+      }
+    ]
+  }
+}

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -1,5 +1,9 @@
 {
   "routes": {
+    "store": {
+      "path": "/",
+      "context": "StoreContextProvider"
+    },
     "store/order": {
       "path": "/order",
       "context": "HomeContextProvider"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -14,27 +14,7 @@
       "component": "DeliveryLayoutContainer",
       "context": "vtex.store@1.x/StoreContextProvider",
       "props": {
-        "elements": ["__children__"]
-      }
-    },
-    "home": {
-      "component": "vtex.render-runtime/LayoutContainer",
-      "props": {
-        "elements": ["theme", "address"]
-      },
-      "extensions": {
-        "theme": {
-          "component": "Theme"
-        },
-        "address": {
-          "component": "vtex.address-locator/index"
-        }
-      }
-    },
-    "order": {
-      "component": "vtex.render-runtime/LayoutContainer",
-      "props": {
-        "elements": ["header", "address-manager", "greeting", "carousel", "last-order", "shelf"]
+        "elements": ["header", "__children__", "footer"]
       },
       "extensions": {
         "header": {
@@ -61,6 +41,28 @@
         "header/search-bar": {
           "component": "vtex.store-components/SearchBar"
         },
+        "footer": {
+          "component": "vtex.dreamstore-footer/index"
+        }
+      }
+    },
+    "home": {
+      "component": "vtex.render-runtime/LayoutContainer",
+      "props": {
+        "elements": ["address"]
+      },
+      "extensions": {
+        "address": {
+          "component": "vtex.address-locator/index"
+        }
+      }
+    },
+    "order": {
+      "component": "vtex.render-runtime/LayoutContainer",
+      "props": {
+        "elements": ["address-manager", "greeting", "carousel", "last-order", "shelf"]
+      },
+      "extensions": {
         "address-manager": {
           "component": "vtex.address-locator/AddressManager"
         },

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -14,7 +14,7 @@
       "component": "DeliveryLayoutContainer",
       "context": "vtex.store@1.x/StoreContextProvider",
       "props": {
-        "elements": ["header", "__children__", "footer"]
+        "elements": ["header", "__children__"]
       },
       "extensions": {
         "header": {
@@ -40,9 +40,6 @@
         },
         "header/search-bar": {
           "component": "vtex.store-components/SearchBar"
-        },
-        "footer": {
-          "component": "vtex.dreamstore-footer/index"
         }
       }
     },

--- a/react/DeliveryLayoutContainer.js
+++ b/react/DeliveryLayoutContainer.js
@@ -1,0 +1,1 @@
+export { default } from './components/DeliveryLayoutContainer'

--- a/react/Greeting.js
+++ b/react/Greeting.js
@@ -1,0 +1,1 @@
+export { default } from './components/Greeting'

--- a/react/MaybeAddress.js
+++ b/react/MaybeAddress.js
@@ -1,0 +1,1 @@
+export { default } from './components/MaybeAddress'

--- a/react/Theme.js
+++ b/react/Theme.js
@@ -1,0 +1,4 @@
+import React, {Fragment} from 'react'
+import './global.css'
+
+export default () => <Fragment />

--- a/react/Theme.js
+++ b/react/Theme.js
@@ -1,4 +1,0 @@
-import React, {Fragment} from 'react'
-import './global.css'
-
-export default () => <Fragment />

--- a/react/components/DeliveryLayoutContainer.js
+++ b/react/components/DeliveryLayoutContainer.js
@@ -1,0 +1,16 @@
+import React, { Component } from 'react'
+import { LayoutContainer } from 'render'
+
+import MaybeAddress from './MaybeAddress'
+
+class DeliveryLayoutContainer extends Component {
+  render() {
+    return (
+      <MaybeAddress>
+        <LayoutContainer {...this.props} />
+      </MaybeAddress>
+    )
+  }
+}
+
+export default DeliveryLayoutContainer

--- a/react/components/DeliveryLayoutContainer.js
+++ b/react/components/DeliveryLayoutContainer.js
@@ -4,6 +4,7 @@ import { LayoutContainer } from 'render'
 import '../global.css'
 import MaybeAddress from './MaybeAddress'
 
+/** TODO - This is a theme app, we shouldn't have React components on this type of app. Redesign this solution after MVP. */
 class DeliveryLayoutContainer extends Component {
   render() {
     return (

--- a/react/components/DeliveryLayoutContainer.js
+++ b/react/components/DeliveryLayoutContainer.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { LayoutContainer } from 'render'
 
+import '../global.css'
 import MaybeAddress from './MaybeAddress'
 
 class DeliveryLayoutContainer extends Component {

--- a/react/components/Greeting.js
+++ b/react/components/Greeting.js
@@ -1,0 +1,65 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+import { graphql } from 'react-apollo'
+import { compose, branch, withProps, renderComponent } from 'recompose'
+import { FormattedMessage } from 'react-intl'
+import { withSession } from 'render'
+import { session } from 'vtex.store/Queries'
+
+import GreetingLoading from './GreetingLoading'
+
+const Wrapper = Component => props => (
+  <div className="vtex-page-loading mh7 pv4 f3 fw4 c-on-base">
+    <Component {...props} />
+  </div>
+)
+
+const Greeting = ({ profile }) => {
+  if (!profile) return null
+
+  return (
+    <div className="vtex-page-loading mh7 pv4 f3 fw4 c-on-base">
+      {profile.firstName ? (
+        <Fragment>
+          <span className="pr2">
+            <FormattedMessage id="delivery-dreamstore.greeting" />,
+          </span>
+          <span className="fw6 nowrap">{profile.firstName}</span>
+        </Fragment>
+      ) : (
+        <div className="nowrap">
+          <FormattedMessage id="delivery-dreamstore.greeting" />!
+        </div>
+      )}
+    </div>
+  )
+}
+
+Greeting.defaultProps = {
+  profile: {},
+}
+
+Greeting.propTypes = {
+  profile: PropTypes.shape({
+    firstName: PropTypes.string,
+  }),
+}
+
+const WrappedLoading = Wrapper(GreetingLoading)
+
+const options = {
+  name: 'session',
+  options: () => ({ ssr: false }),
+}
+
+const enhanced = compose(
+  withSession({ loading: <WrappedLoading /> }),
+  graphql(session, options),
+  branch(
+    ({ session, loading }) => loading || !session.getSession,
+    renderComponent(WrappedLoading),
+    withProps(({ session }) => ({ profile: session.getSession.profile }))
+  )
+)
+
+export default enhanced(Greeting)

--- a/react/components/GreetingLoading.js
+++ b/react/components/GreetingLoading.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import ContentLoader from 'react-content-loader'
+
+const GreetingLoading = props => (
+  <ContentLoader
+    height={32}
+    width={300}
+    speed={2}
+    primaryColor="#f3f3f3"
+    secondaryColor="#ecebeb"
+    className="v-mid"
+    {...props}
+  >
+    <rect rx="1" ry="1" width="300" height="32" />
+  </ContentLoader>
+)
+
+export default GreetingLoading

--- a/react/components/MaybeAddress.js
+++ b/react/components/MaybeAddress.js
@@ -73,7 +73,7 @@ class MaybeAddress extends Component {
 
     const redirectPath = this.getRedirectPath()
 
-    if (redirectPath)
+    if (redirectPath) {
       return (
         <Redirect
           to={redirectPath}
@@ -81,8 +81,9 @@ class MaybeAddress extends Component {
           shouldReturn={redirectPath === homePage}
         />
       )
+    }
 
-    return children ? children : null
+    return children || null
   }
 }
 

--- a/react/components/MaybeAddress.js
+++ b/react/components/MaybeAddress.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { compose } from 'recompose'
 import { orderFormConsumer, contextPropTypes } from 'vtex.store/OrderFormContext'
-import { withRuntimeContext, Loading } from 'render'
+import { withRuntimeContext } from 'render'
 
 import Redirect from './Redirect'
 

--- a/react/components/MaybeAddress.js
+++ b/react/components/MaybeAddress.js
@@ -60,7 +60,7 @@ class MaybeAddress extends Component {
       return runtime.pages[homePage].path
     } else if (runtime.page === homePage && isIdentified) {
       /**
-       * is the user lands on the home page for some reason but
+       * If the user lands on the home page for some reason but
        * it's already identified, redirect to the order page
        */
       return runtime.pages[orderPage].path
@@ -78,7 +78,7 @@ class MaybeAddress extends Component {
         <Redirect
           to={redirectPath}
           navigate={runtime.navigate}
-          shouldReturn={redirectPath === homePage}
+          shouldReturn={redirectPath === runtime.pages[homePage].path}
         />
       )
     }

--- a/react/components/MaybeAddress.js
+++ b/react/components/MaybeAddress.js
@@ -1,0 +1,73 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { compose } from 'recompose'
+import { orderFormConsumer, contextPropTypes } from 'vtex.store/OrderFormContext'
+import { withRuntimeContext, Loading } from 'render'
+
+import Redirect from './Redirect'
+
+/**
+ * If necessary, this redirects the user to the Address Locator page
+ *
+ * The user can be "identified" in thre ways:
+ * - Has added their address on orderForm but is otherwise anonymous
+ * - Has identified their email
+ * - Has authenticated (thus being almost the same as the one above)
+ *
+ * For all of the above cases, just checking if there is an address
+ * on the orderForm is enough to cover all edge cases
+ *
+ * With the bonus that it can be done on SSR, something that querying
+ * the user profile can not do
+ */
+class MaybeAddress extends Component {
+  static propTypes = {
+    orderFormContext: contextPropTypes,
+    pageToRedirect: PropTypes.string,
+    runtime: PropTypes.shape({
+      page: PropTypes.string.isRequired,
+      pages: PropTypes.object.isRequired,
+    }).isRequired,
+  }
+
+  static defaultProps = {
+    pageToRedirect: 'store',
+  }
+
+  get redirectPath() {
+    const { runtime, pageToRedirect } = this.props
+    return runtime.pages[pageToRedirect].path
+  }
+
+  get isLandingPage() {
+    const { runtime } = this.props
+    return !!runtime.pages[runtime.page].landing
+  }
+
+  shouldRedirect() {
+    const {
+      runtime,
+      pageToRedirect,
+      orderFormContext: { orderForm, loading },
+    } = this.props
+
+    if (loading) return false
+
+    const isIdentified = orderForm.shippingData && orderForm.shippingData.address
+    return runtime.page !== pageToRedirect && !this.isLandingPage && !isIdentified
+  }
+
+  render() {
+    const { orderFormContext, runtime, children, ...parentProps } = this.props
+
+    if (this.shouldRedirect())
+      return <Redirect to={this.redirectPath} navigate={runtime.navigate} shouldReturn />
+
+    return children ? children : null
+  }
+}
+
+export default compose(
+  orderFormConsumer,
+  withRuntimeContext
+)(MaybeAddress)

--- a/react/components/MaybeAddress.js
+++ b/react/components/MaybeAddress.js
@@ -20,6 +20,7 @@ import Redirect from './Redirect'
  * With the bonus that it can be done on SSR, something that querying
  * the user profile can not do
  */
+/** TODO - This is a theme app, we shouldn't have React components on this type of app. Redesign this solution after MVP. */
 class MaybeAddress extends Component {
   static propTypes = {
     orderFormContext: contextPropTypes,

--- a/react/components/Redirect.js
+++ b/react/components/Redirect.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { canUseDOM } from 'exenv'
+
+class Redirect extends Component {
+  static propTypes = {
+    /* Path to redirect to */
+    to: PropTypes.string.isRequired,
+    /* Render Provider's navigate method */
+    navigate: PropTypes.func.isRequired,
+    /* If the next page should return to the current one after a certain user action */
+    shouldReturn: PropTypes.bool,
+  }
+
+  componentDidMount() {
+    const { navigate, to, shouldReturn } = this.props
+
+    // This makes the redirect code only be executed on the browser
+    if (!canUseDOM) return
+
+    if (to) {
+      navigate({
+        fallbackToWindowLocation: false,
+        to,
+        ...(shouldReturn
+          ? { query: `returnUrl=${window.location.pathname.replace(/\/$/, '')}` }
+          : {}),
+      })
+    }
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default Redirect

--- a/react/global.css
+++ b/react/global.css
@@ -1,0 +1,8 @@
+html {
+    height: 100%;
+}
+
+.render-route-store-home {
+    background-color: #eee;
+    height: 100%;
+}

--- a/react/global.css
+++ b/react/global.css
@@ -1,8 +1,14 @@
 html {
-    height: 100%;
+  height: 100%;
 }
 
-.render-route-store-home .vtex-address-locator {
-    background-color: #eee;
-    height: 100%;
+.render-route-store-home {
+  background-color: #eee;
+  height: 100%;
+}
+
+/* Hides header on home page */
+.render-route-store-home .vtex-header,
+.render-route-store-home .vtex-modal-root .vtex-top-menu {
+  display: none;
 }

--- a/react/global.css
+++ b/react/global.css
@@ -2,7 +2,7 @@ html {
     height: 100%;
 }
 
-.render-route-store-home {
+.render-route-store-home .vtex-address-locator {
     background-color: #eee;
     height: 100%;
 }

--- a/react/graphql/getGreeting.gql
+++ b/react/graphql/getGreeting.gql
@@ -1,0 +1,6 @@
+query Greeting @context(scope: "private") {
+  profile {
+    cacheId
+    firstName
+  }
+}

--- a/react/index.js
+++ b/react/index.js
@@ -1,9 +1,0 @@
-import React, { Component } from 'react'
-
-class Hello extends Component {
-    render() {
-        return <div>Hello world!</div>
-    }
-}
-
-export default Hello

--- a/react/index.js
+++ b/react/index.js
@@ -1,0 +1,9 @@
+import React, { Component } from 'react'
+
+class Hello extends Component {
+    render() {
+        return <div>Hello world!</div>
+    }
+}
+
+export default Hello

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -1,0 +1,3 @@
+{
+    "delivery-dreamstore.greeting": "Hello"
+}

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -1,0 +1,3 @@
+{
+    "delivery-dreamstore.greeting": "Hola"
+}

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -1,0 +1,3 @@
+{
+    "delivery-dreamstore.greeting": "Olá"
+}

--- a/react/package.json
+++ b/react/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "vtex.delivery-dreamstore",
+  "version": "0.1.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "react-content-loader": "^3.2.0",
+    "recompose": "^0.30.0"
+  }
+}


### PR DESCRIPTION
This PR serves to config pages.json with the specific apps for delivery and add a Address identification and Redirection component

The main feature in this is the MaybeAddress component. It should be considered WIP because atm there's no way to do that on the same level on the react tree as MaybeAuth from render, so this is happening at the layout level. 
The way it works is, if the user tries to access a page that's not the home (aka the address locator app) or that's not configured as a landing page, and it's not identified yet (has a address in orderForm), it will redirect to the home. The opposite is also true, if for any reason an identified user lands on the home page, redirect it to the order page.

Testing:
- Try to access https://layout--delivery.myvtex.com/order or any other non landing page
- It should redirect you to https://layout--delivery.myvtex.com/
- Use the Address Locator app to identify your address
- You will be redirected to the Order Page https://layout--delivery.myvtex.com/order and be able to have full access to all pages that don't require authentication
- Try to access the home page https://layout--delivery.myvtex.com/, it should take you to the Order page again if you're already identified