### PR TITLE
Remove order page and putting all it's content on home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2018-11-06
 ### Changed
 Removed `/order` and put all it's content in `/home`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+Removed `/order` and put all it's content in `/home`.
 
 ## [0.3.3] - 2018-11-06
 ### Removed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "delivery-dreamstore",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -1,20 +1,13 @@
 {
   "extensions": {
     "store/header": {
-      "component": "vtex.dreamstore-header/index",
-      "props": {
-        "leanWhen": "store/home"
-      }
+      "component": "vtex.dreamstore-header/index"
     }
   },
   "routes": {
     "store": {
       "path": "/",
       "context": "StoreContextProvider"
-    },
-    "store/order": {
-      "path": "/order",
-      "context": "HomeContextProvider"
     },
     "store/home": {
       "path": "/",
@@ -61,17 +54,6 @@
     "home": {
       "component": "vtex.render-runtime/LayoutContainer",
       "props": {
-        "elements": ["address"]
-      },
-      "extensions": {
-        "address": {
-          "component": "vtex.address-locator/Tabs"
-        }
-      }
-    },
-    "order": {
-      "component": "vtex.render-runtime/LayoutContainer",
-      "props": {
         "elements": ["address-manager", "greeting", "carousel", "rebuy", "shelf"]
       },
       "extensions": {
@@ -116,12 +98,6 @@
       {
         "name": "Default",
         "template": "home"
-      }
-    ],
-    "store/order": [
-      {
-        "name": "Order",
-        "template": "order"
       }
     ],
     "store/product": [


### PR DESCRIPTION
#### What is the purpose of this pull request?
Removed `/order` and put all it's content in `/home`.

#### What problem is this solving?
We'll no longer need both pages since the address collector will be in a modal in the new home.