### PR TITLE
Remove "Departments" category from header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.3] - 2018-11-06
 ### Removed
 - Removed "Departments" tab from categories menu
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Removed "Departments" tab from categories menu
 
 ## [0.4.2] - 2018-11-06
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "delivery-dreamstore",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/pages/pages.json
+++ b/pages/pages.json
@@ -38,7 +38,10 @@
           "component": "vtex.menu/Menu"
         },
         "header/category-menu": {
-          "component": "vtex.category-menu/index"
+          "component": "vtex.category-menu/index",
+          "props": {
+            "showDepartmentsCategory": false
+          }
         },
         "header/logo": {
           "component": "vtex.store-components/Logo"


### PR DESCRIPTION
#### What is the purpose of this pull request?
To use the feature introduced on [Category Menu PR #26](https://github.com/vtex-apps/category-menu/pull/26) to remove the Department category from the header.

#### What problem is this solving?
Stores with few categories still have the departments entry on the category header. This duplicates information and takes focus from the main categories (e.g. pizzas in PizzaHut)

#### Screenshots or example usage
<img width="1280" alt="screen shot 2018-11-06 at 16 07 54" src="https://user-images.githubusercontent.com/7853668/48084460-effb1900-e1de-11e8-9d96-fae19a1772d7.png">

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.