### PR TITLE
Add loading on MaybeAddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.5] - 2018-11-07
+
 ### Changed
 - Add a loading screen while loading the order form context, before deciding whether the user should be redirected to the address screen or not
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Add a loading screen while loading the order form context, before deciding whether the user should be redirected to the address screen or not
+
 ## [0.4.4] - 2018-11-07
 ### Removed
 - Removed subcategories from categories menu

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "delivery-dreamstore",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "builders": {
     "pages": "0.x",
     "react": "2.x"

--- a/react/components/MaybeAddress.js
+++ b/react/components/MaybeAddress.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { compose } from 'recompose'
 import { orderFormConsumer, contextPropTypes } from 'vtex.store/OrderFormContext'
 import { withRuntimeContext } from 'render'
+import { Spinner } from 'vtex.styleguide'
 
 import Redirect from './Redirect'
 
@@ -69,7 +70,20 @@ class MaybeAddress extends Component {
   }
 
   render() {
-    const { runtime, homePage, children } = this.props
+    const {
+      runtime,
+      homePage,
+      children,
+      orderFormContext : {loading},
+    } = this.props
+
+    if (loading) {
+      return (
+        <div className="flex items-center justify-center fixed absolute--fill z-999 bg-white c-action-primary">
+          <Spinner />
+        </div>
+      )
+    }
 
     const redirectPath = this.getRedirectPath()
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

Adds a loading spinner while the OrderFormContext is being loaded, before deciding whether the user should input an address or not.

https://addresslocatorspinner--delivery.myvtex.com/

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.